### PR TITLE
Add Preset

### DIFF
--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -49,14 +49,14 @@ namespace esphome {
         const uint8_t MHI_3DAUTO_OFF = 0x12;
 
         // NOT available in Fan or Dry mode
-        const uint8_t MHI_SILENT_ON = 0x00;
-        const uint8_t MHI_SILENT_OFF = 0x80;
+        const uint8_t MHI_SILENT_ON = 0x80;
+        const uint8_t MHI_SILENT_OFF = 0x00;
         
         // Night setback 
-        const uint8_t MHI_NIGHT_ON = 0x00;
-        const uint8_t MHI_NIGHT_OFF = 0x40;
+        const uint8_t MHI_NIGHT_ON = 0x40;
+        const uint8_t MHI_NIGHT_OFF = 0x00;
         
-        // "inverted" to get ECO working.
+        // Eco
         const uint8_t MHI_ECO_ON = 0x00;
         const uint8_t MHI_ECO_OFF = 0x10;
 
@@ -226,7 +226,7 @@ namespace esphome {
                 0x52, 0xAE, 0xC3, 0x1A,
                 0xE5, 0x90, 0x00, 0xF0,
                 0x00, 0xE0, 0x00, 0x0D,
-                0x00, 0x10, 0x00, 0xBF,
+                0x00, 0x10, 0x00, 0x3F,
                 0x00, 0x7F, 0x00
             };
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -194,7 +194,9 @@ namespace esphome {
                             this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
                             break;
                     }
-                case MHI_ECONO: // Not yet supported. Will be added when ESPHome supports it.
+                case MHI_ECONO: //added ECO as Preset
+                    this->fan_mode = climate::CLIMATE_PRESET_ECO;
+                    break;
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
                     break;
@@ -307,6 +309,9 @@ namespace esphome {
                 case climate::CLIMATE_FAN_DIFFUSE:
                     fanSpeed = MHI_FAN_AUTO;
                     swingH = MHI_HS_LEFTRIGHT;
+                    break;
+               case climate::climate::CLIMATE_PRESET_ECO: //Preset mode to set unit to ECO
+                    fanSpeed = MHI_ECO;
                     break;
                 case climate::CLIMATE_FAN_AUTO:
                 default:

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -56,9 +56,9 @@ namespace esphome {
         const uint8_t MHI_NIGHT_ON = 0x00;
         const uint8_t MHI_NIGHT_OFF = 0x40;
         
-        // NOT available in Fan mode
-        const uint8_t MHI_ECO_ON = 0x10;
-        const uint8_t MHI_ECO_OFF = 0x00;
+        // "inverted" to get ECO working.
+        const uint8_t MHI_ECO_ON = 0x00;
+        const uint8_t MHI_ECO_OFF = 0x10;
 
         // Pulse parameters in usec
         const uint16_t MHI_BIT_MARK = 400;
@@ -225,7 +225,7 @@ namespace esphome {
             uint8_t remote_state[] = {
                 0x52, 0xAE, 0xC3, 0x1A,
                 0xE5, 0x90, 0x00, 0xF0,
-                0x00, 0xF0, 0x00, 0x0D,
+                0x00, 0xE0, 0x00, 0x0D,
                 0x00, 0x10, 0x00, 0xBF,
                 0x00, 0x7F, 0x00
             };

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -313,6 +313,7 @@ namespace esphome {
                     swingH = MHI_HS_LEFTRIGHT;
                     break;
                 case climate::CLIMATE_FAN_AUTO:
+                    fanSpeed = MHI_FAN_AUTO;
                 default:
                     fanSpeed = MHI_FAN_AUTO;
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -195,7 +195,7 @@ namespace esphome {
                             break;
                     }
                 case MHI_ECONO: //added ECO as Preset
-                    this->fan_mode = climate::CLIMATE_PRESET_ECO;
+                    this->preset_mode = climate::CLIMATE_PRESET_ECO;
                     break;
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
@@ -310,12 +310,14 @@ namespace esphome {
                     fanSpeed = MHI_FAN_AUTO;
                     swingH = MHI_HS_LEFTRIGHT;
                     break;
-               case climate::CLIMATE_PRESET_ECO: //Preset mode to set unit to ECO
-                    fanSpeed = MHI_ECONO;
-                    break;
                 case climate::CLIMATE_FAN_AUTO:
                 default:
                     fanSpeed = MHI_FAN_AUTO;
+                    break;
+            }
+            switch (this->preset_mode.value()) {
+                case climate::CLIMATE_PRESET_ECO:
+                    fanSpeed = MHI_ECO;
                     break;
             }
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -320,10 +320,10 @@ namespace esphome {
             
             switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_ECO:
-                    fanSpeed = MHI_ECONO;  //proebly needs power on and AUTO
+                    fanSpeed = MHI_ECONO;  //probebly needs power on and AUTO
                     break;
-                case CLIMATE_PRESET_BOOST:
-                    fanSpeed = MHI_HIPOWER; //proebly needs power on and AUTO
+                case climate::CLIMATE_PRESET_BOOST:
+                    fanSpeed = MHI_HIPOWER; //probebly needs power on and AUTO
                     break;
                 case climate::CLIMATE_PRESET_NONE:
                 default: //set None to default - no action

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -199,12 +199,12 @@ namespace esphome {
                         case MHI_HS_LEFTRIGHT:
                             this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
                             break;
-                        case MHI_HS_SWING;
-                        case MHI_HS_LEFT;
-                        case MHI_HS_MLEFT;
-                        case MHI_HS_MRIGHT;
-                        case MHI_HS_RIGHT;
-                        case MHI_HS_STOP;
+                        case MHI_HS_SWING:
+                        case MHI_HS_LEFT:
+                        case MHI_HS_MLEFT:
+                        case MHI_HS_MRIGHT:
+                        case MHI_HS_RIGHT:
+                        case MHI_HS_STOP:
                     }
                 case MHI_HIPOWER: // Set via BOOST Preset
                  //   this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -311,7 +311,7 @@ namespace esphome {
                     swingH = MHI_HS_LEFTRIGHT;
                     break;
                case climate::CLIMATE_PRESET_ECO: //Preset mode to set unit to ECO
-                    fanSpeed = MHI_ECO;
+                    fanSpeed = MHI_ECONO;
                     break;
                 case climate::CLIMATE_FAN_AUTO:
                 default:

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -323,19 +323,18 @@ namespace esphome {
             switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_NONE:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
-                    fanSpeed = MHI_FAN_AUTO; // set fan to Auto
-                    operatingMode = MHI_AUTO; //set mode to Auto
                     ecoMode = MHI_ECO_OFF; //set echo mode OFF
                     break;
                 case climate::CLIMATE_PRESET_ECO:
+                    _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     ecoMode = MHI_ECO_ON;  // set device to Eco mode
                     break;
                 case climate::CLIMATE_PRESET_BOOST:
+                    _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     fanSpeed = MHI_HIPOWER; // set device to high fan
                     break;
                 case climate::CLIMATE_PRESET_ACTIVITY:
                     _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
-                    operatingMode = MHI_AUTO;
                     break;
                 default: //set None to default - no action
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -52,7 +52,7 @@ namespace esphome {
         const uint8_t MHI_SILENT_ON = 0x00;
         const uint8_t MHI_SILENT_OFF = 0x80;
         
-        // Night setback
+        // Night setback 
         const uint8_t MHI_NIGHT_ON = 0x00;
         const uint8_t MHI_NIGHT_OFF = 0x40;
         
@@ -226,7 +226,7 @@ namespace esphome {
                 0x52, 0xAE, 0xC3, 0x1A,
                 0xE5, 0x90, 0x00, 0xF0,
                 0x00, 0xF0, 0x00, 0x0D,
-                0x00, 0x10, 0x00, 0xFF,
+                0x00, 0x10, 0x00, 0xBF,
                 0x00, 0x7F, 0x00
             };
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -179,14 +179,6 @@ namespace esphome {
             switch (fanSpeed) {
                 case MHI_FAN1: 
                     this->fan_mode = climate::CLIMATE_FAN_LOW;
-                    switch (ecoMode) {
-                        case MHI_ECO_ON;
-                            this->preset = climate::CLIMATE_PRESET_ECO;
-                            break;
-                        case MHI_ECO_OFF;
-                            this->preset = climate::CLIMATE_PRESET_NONE;
-                            break;
-                    }
                     break;
                 case MHI_FAN2: // Only to support remote feedback
                 case MHI_FAN3:

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -144,9 +144,10 @@ namespace esphome {
                     case MHI_DRY:
                         this->mode = climate::CLIMATE_MODE_DRY;
                         break;
+                    case MHI_AUTO:
+                        this->mode = climate::CLIMATE_MODE_HEAT_COOL;  //AUTO don´t exist in climate_ir
+                        breakt
                     default:
-                        this->mode = climate::CLIMATE_MODE_HEAT_COOL; //AUTO don´t exist in climate_ir
-                        // swingV = MHI_VS_MIDDLE;
                         break;
                 }
             } else {
@@ -320,8 +321,8 @@ namespace esphome {
             
             switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_NONE:
-                    _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
-                    fanSpeed = MHI_FAN_AUTO; // set fan to Auto
+               //     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
+              //      fanSpeed = MHI_FAN_AUTO; // set fan to Auto
                     operatingMode = MHI_AUTO; //set mode to Auto
                     break;
                 case climate::CLIMATE_PRESET_ECO:
@@ -331,8 +332,8 @@ namespace esphome {
                     fanSpeed = MHI_HIPOWER; // set device to high fan
                     break;
                 case climate::CLIMATE_PRESET_ACTIVITY:
-                    _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
-                    operatingMode = MHI_AUTO;
+               //     _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
+              //      operatingMode = MHI_AUTO;
                     break;
                 default: //set None to default - no action
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -343,6 +343,7 @@ namespace esphome {
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     ecoMode = MHI_ECO_ON;  // set device to Eco mode
                     nightMode = MHI_NIGHT_OFF; //set night off
+                    fanSpeed = MHI_FAN2; //set fan speed
                     break;
                 case climate::CLIMATE_PRESET_BOOST:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -317,7 +317,7 @@ namespace esphome {
             }
             switch (this->preset_mode.value()) {
                 case climate::CLIMATE_PRESET_ECO:
-                    fanSpeed = MHI_ECO;
+                    fanSpeed = MHI_ECONO;
                     break;
             }
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -320,6 +320,10 @@ namespace esphome {
             }
             
             switch (this->preset.value()) {
+                case climate::CLIMATE_PRESET_NONE:
+                    _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
+                    fanSpeed = MHI_FAN_AUTO; // set fan to Auto
+                    break;
                 case climate::CLIMATE_PRESET_ECO:
                     fanSpeed = MHI_ECONO;  // set device to Eco mode
                     break;
@@ -328,10 +332,6 @@ namespace esphome {
                     break;
                 case climate::CLIMATE_PRESET_ACTIVITY:
                     _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
-                    break;
-                case climate::CLIMATE_PRESET_NONE:
-                    _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
-                    fanSpeed = MHI_FAN_AUTO; // set fan to Auto
                     break;
                 default: //set None to default - no action
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -315,9 +315,14 @@ namespace esphome {
                     fanSpeed = MHI_FAN_AUTO;
                     break;
             }
+            
             switch (this->preset_mode.value()) {
                 case climate::CLIMATE_PRESET_ECO:
                     fanSpeed = MHI_ECONO;
+                    break;
+                default:
+                    fanSpeed = MHI_FAN_AUTO;
+                    // set to auto. 
                     break;
             }
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -178,8 +178,7 @@ namespace esphome {
                     this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
                     break;
                 case MHI_FAN4:
-                case MHI_HIPOWER: // Not yet supported. Will be added when ESPHome supports it.
-                    this->fan_mode = climate::CLIMATE_FAN_HIGH;
+                    this->fan_mode = climate::CLIMATE_FAN_HIGH; // Moved to Fan4
                     break;
                 case MHI_FAN_AUTO:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
@@ -194,9 +193,12 @@ namespace esphome {
                             this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
                             break;
                     }
-                case MHI_ECONO: //added ECO as Preset
+                case MHI_ECONO: // Set via ECO Preset
                     this->preset = climate::CLIMATE_PRESET_ECO;
                     break;
+                case MHI_HIPOWER: // Set via BOOST Preset
+                    this->preset = climate::CLIMATE_PRESET_BOOST;
+                    break;                    
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
                     break;
@@ -318,11 +320,13 @@ namespace esphome {
             
             switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_ECO:
-                    fanSpeed = MHI_ECONO;
+                    fanSpeed = MHI_ECONO;  //proebly needs power on and AUTO
                     break;
-                default:
-                    fanSpeed = MHI_FAN_AUTO;
-                    // set to auto. 
+                case CLIMATE_PRESET_BOOST:
+                    fanSpeed = MHI_HIPOWER; //proebly needs power on and AUTO
+                    break;
+                case climate::CLIMATE_PRESET_NONE:
+                default: //set None to default - no action
                     break;
             }
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -145,7 +145,6 @@ namespace esphome {
                         this->mode = climate::CLIMATE_MODE_DRY;
                         break;
                     default:
-                    case MHI_AUTO:
                         this->mode = climate::CLIMATE_MODE_AUTO;
                         // swingV = MHI_VS_MIDDLE;
                         break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -52,6 +52,10 @@ namespace esphome {
         const uint8_t MHI_SILENT_ON = 0x00;
         const uint8_t MHI_SILENT_OFF = 0x80;
         
+        // Night setback
+        const uint8_t MHI_NIGHT_ON = 0x00;
+        const uint8_t MHI_NIGHT_OFF = 0x40;
+        
         // NOT available in Fan mode
         const uint8_t MHI_ECO_ON = 0x10;
         const uint8_t MHI_ECO_OFF = 0x00;
@@ -235,6 +239,7 @@ namespace esphome {
             auto _3DAuto = MHI_3DAUTO_OFF;
             auto ecoMode = MHI_ECO_OFF;
             auto silentMode = MHI_SILENT_OFF;
+            auto nightMode = MHI_NIGHT_OFF;
 
             // ----------------------
             // Assign the values
@@ -324,17 +329,21 @@ namespace esphome {
                 case climate::CLIMATE_PRESET_NONE:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     ecoMode = MHI_ECO_OFF; //set echo mode OFF
+                    nightMode = MHI_NIGHT_OFF; //set night off
                     break;
                 case climate::CLIMATE_PRESET_ECO:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     ecoMode = MHI_ECO_ON;  // set device to Eco mode
+                    nightMode = MHI_NIGHT_OFF; //set night off
                     break;
                 case climate::CLIMATE_PRESET_BOOST:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     fanSpeed = MHI_HIPOWER; // set device to high fan
+                    nightMode = MHI_NIGHT_OFF; //set night off
                     break;
                 case climate::CLIMATE_PRESET_ACTIVITY:
                     _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
+                    nightMode = MHI_NIGHT_ON; // set nightmode on
                     break;
                 default: //set None to default - no action
                     break;
@@ -359,8 +368,8 @@ namespace esphome {
             // Horizontal air flow
             remote_state[13] |= swingV | swingH;
 
-            // Silent
-            remote_state[15] |= silentMode;
+            // Silent and Night mode
+            remote_state[15] |= silentMode | nightMode;
 
             // There is no real checksum, but some bytes are inverted
             remote_state[6] = ~remote_state[5];

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -146,7 +146,7 @@ namespace esphome {
                         break;
                     case MHI_AUTO:
                         this->mode = climate::CLIMATE_MODE_HEAT_COOL;  //AUTO don´t exist in climate_ir
-                        breakt
+                        break;
                     default:
                         break;
                 }

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -195,7 +195,7 @@ namespace esphome {
                             break;
                     }
                 case MHI_ECONO: //added ECO as Preset
-                    this->preset_mode = climate::CLIMATE_PRESET_ECO;
+                    this->preset = climate::CLIMATE_PRESET_ECO;
                     break;
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
@@ -316,7 +316,7 @@ namespace esphome {
                     break;
             }
             
-            switch (this->preset_mode.value()) {
+            switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_ECO:
                     fanSpeed = MHI_ECONO;
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -145,7 +145,7 @@ namespace esphome {
                         this->mode = climate::CLIMATE_MODE_DRY;
                         break;
                     default:
-                        this->mode = climate::CLIMATE_MODE_AUTO;
+                        this->mode = climate::CLIMATE_MODE_HEAT_COOL; //AUTO don´t exist in climate_ir
                         // swingV = MHI_VS_MIDDLE;
                         break;
                 }
@@ -240,7 +240,7 @@ namespace esphome {
 
             // Power and operating mode
             switch (this->mode) {
-              case climate::CLIMATE_MODE_AUTO:
+              case climate::CLIMATE_MODE_HEAT_COOL:
                     operatingMode = MHI_AUTO;
                     swingV = MHI_VS_MIDDLE; // custom preferred value for this mode
                     break;
@@ -322,6 +322,7 @@ namespace esphome {
                 case climate::CLIMATE_PRESET_NONE:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     fanSpeed = MHI_FAN_AUTO; // set fan to Auto
+                    operatingMode = MHI_AUTO; //set mode to Auto
                     break;
                 case climate::CLIMATE_PRESET_ECO:
                     fanSpeed = MHI_ECONO;  // set device to Eco mode
@@ -331,6 +332,7 @@ namespace esphome {
                     break;
                 case climate::CLIMATE_PRESET_ACTIVITY:
                     _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
+                    operatingMode = MHI_AUTO;
                     break;
                 default: //set None to default - no action
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -320,12 +320,18 @@ namespace esphome {
             
             switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_ECO:
-                    fanSpeed = MHI_ECONO;  //probebly needs power on and AUTO
+                    fanSpeed = MHI_ECONO;  // set device to Eco mode
                     break;
                 case climate::CLIMATE_PRESET_BOOST:
-                    fanSpeed = MHI_HIPOWER; //probebly needs power on and AUTO
+                    fanSpeed = MHI_HIPOWER; // set device to high fan
+                    break;
+                case climate::CLIMATE_PRESET_ACTIVITY:
+                    _3DAuto = MHI_3DAUTO_ON; // set 3dmode to on
                     break;
                 case climate::CLIMATE_PRESET_NONE:
+                    _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
+                    fanSpeed = MHI_FAN_AUTO; // set fan to Auto
+                    break;
                 default: //set None to default - no action
                     break;
             }

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -189,27 +189,27 @@ namespace esphome {
                     break;
                 case MHI_FAN_AUTO:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
-                    switch (swingH) {     
-                        case MHI_HS_SWING:
-                        case MHI_HS_LEFT:
-                        case MHI_HS_MLEFT:
-                        case MHI_HS_MRIGHT:
-                        case MHI_HS_RIGHT:
-                        case MHI_HS_STOP:
-                        case MHI_HS_MIDDLE:
-                            this->fan_mode = climate::CLIMATE_FAN_MIDDLE;
-                            break;
-                        case MHI_HS_RIGHTLEFT:
-                            this->fan_mode = climate::CLIMATE_FAN_FOCUS;
-                            break;
-                        case MHI_HS_LEFTRIGHT:
-                            this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
-                            break;  
-                    }
+             //       switch (swingH) {     
+             //           case MHI_HS_SWING:
+             //           case MHI_HS_LEFT:
+             //           case MHI_HS_MLEFT:
+             //           case MHI_HS_MRIGHT:
+             //           case MHI_HS_RIGHT:
+             //           case MHI_HS_STOP:
+             //           case MHI_HS_MIDDLE:
+             //               this->fan_mode = climate::CLIMATE_FAN_MIDDLE;
+             //               break;
+             //           case MHI_HS_RIGHTLEFT:
+             //               this->fan_mode = climate::CLIMATE_FAN_FOCUS;
+             //               break;
+             //           case MHI_HS_LEFTRIGHT:
+             //               this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
+             //               break;  
+             //       }
                     break;
                 case MHI_HIPOWER: // Set via BOOST Preset
-                 //   this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.
-                 //   break;                    
+                    this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.
+                    break;                    
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -179,6 +179,14 @@ namespace esphome {
             switch (fanSpeed) {
                 case MHI_FAN1: 
                     this->fan_mode = climate::CLIMATE_FAN_LOW;
+                    switch (ecoMode) {
+                        case MHI_ECO_ON;
+                            this->preset = climate::CLIMATE_PRESET_ECO;
+                            break;
+                        case MHI_ECO_OFF;
+                            this->preset = climate::CLIMATE_PRESET_NONE;
+                            break;
+                    }
                     break;
                 case MHI_FAN2: // Only to support remote feedback
                 case MHI_FAN3:
@@ -206,6 +214,7 @@ namespace esphome {
                             this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
                             break;  
                     }
+                    break;
                 case MHI_HIPOWER: // Set via BOOST Preset
                  //   this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.
                  //   break;                    

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -22,8 +22,8 @@ namespace esphome {
         const uint8_t MHI_FAN2 = 0x0D;
         const uint8_t MHI_FAN3 = 0x0C;
         const uint8_t MHI_FAN4 = 0x0B;
-        const uint8_t MHI_HIPOWER = 0x07;
-        const uint8_t MHI_ECONO = 0x00;
+        const uint8_t MHI_HIPOWER = 0x03; //changed from 0x07 to 0x03
+        const uint8_t MHI_ECONO = 0x1F; // ECO AUTO - echo set second bit from 0 to 1, then fan speed can be 1-4
 
         // Vertical swing
         const uint8_t MHI_VS_SWING = 0xE0;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -49,12 +49,12 @@ namespace esphome {
         const uint8_t MHI_3DAUTO_OFF = 0x12;
 
         // NOT available in Fan or Dry mode
-        const uint8_t MHI_SILENT_ON = 0x80;
-        const uint8_t MHI_SILENT_OFF = 0x00;
+        const uint8_t MHI_SILENT_ON = 0x00;
+        const uint8_t MHI_SILENT_OFF = 0x80;
         
         // Night setback 
-        const uint8_t MHI_NIGHT_ON = 0x40;
-        const uint8_t MHI_NIGHT_OFF = 0x00;
+        const uint8_t MHI_NIGHT_ON = 0x00;
+        const uint8_t MHI_NIGHT_OFF = 0x40;
         
         // Eco
         const uint8_t MHI_ECO_ON = 0x00;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -197,7 +197,7 @@ namespace esphome {
                             break;
                     }
                 case MHI_HIPOWER: // Set via BOOST Preset
-                    this->preset = climate::CLIMATE_PRESET_BOOST;
+                 //   this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.
                     break;                    
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -189,7 +189,13 @@ namespace esphome {
                     break;
                 case MHI_FAN_AUTO:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
-                    switch (swingH) {
+                    switch (swingH) {     
+                        case MHI_HS_SWING:
+                        case MHI_HS_LEFT:
+                        case MHI_HS_MLEFT:
+                        case MHI_HS_MRIGHT:
+                        case MHI_HS_RIGHT:
+                        case MHI_HS_STOP:
                         case MHI_HS_MIDDLE:
                             this->fan_mode = climate::CLIMATE_FAN_MIDDLE;
                             break;
@@ -198,13 +204,7 @@ namespace esphome {
                             break;
                         case MHI_HS_LEFTRIGHT:
                             this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
-                            break;
-                        case MHI_HS_SWING:
-                        case MHI_HS_LEFT:
-                        case MHI_HS_MLEFT:
-                        case MHI_HS_MRIGHT:
-                        case MHI_HS_RIGHT:
-                        case MHI_HS_STOP:
+                            break;  
                     }
                 case MHI_HIPOWER: // Set via BOOST Preset
                  //   this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -177,10 +177,10 @@ namespace esphome {
 
             // Fan speed
             switch (fanSpeed) {
-                case MHI_FAN1:
-                case MHI_FAN2: // Only to support remote feedback
+                case MHI_FAN1: 
                     this->fan_mode = climate::CLIMATE_FAN_LOW;
                     break;
+                case MHI_FAN2: // Only to support remote feedback
                 case MHI_FAN3:
                     this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
                     break;
@@ -199,10 +199,16 @@ namespace esphome {
                         case MHI_HS_LEFTRIGHT:
                             this->fan_mode = climate::CLIMATE_FAN_DIFFUSE;
                             break;
+                        case MHI_HS_SWING;
+                        case MHI_HS_LEFT;
+                        case MHI_HS_MLEFT;
+                        case MHI_HS_MRIGHT;
+                        case MHI_HS_RIGHT;
+                        case MHI_HS_STOP;
                     }
                 case MHI_HIPOWER: // Set via BOOST Preset
                  //   this->preset = climate::CLIMATE_PRESET_BOOST; // Problem to get feedback to trigger preset.
-                    break;                    
+                 //   break;                    
                 default:
                     this->fan_mode = climate::CLIMATE_FAN_AUTO;
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -313,20 +313,21 @@ namespace esphome {
                 case climate::CLIMATE_FAN_HIGH:
                     fanSpeed = MHI_FAN4;
                     break;
-                case climate::CLIMATE_FAN_MIDDLE:
-                    fanSpeed = MHI_FAN_AUTO;
-                    swingH = MHI_HS_MIDDLE;
-                    break;
-                case climate::CLIMATE_FAN_FOCUS:
-                    fanSpeed = MHI_FAN_AUTO;
-                    swingH = MHI_HS_RIGHTLEFT;
-                    break;
-                case climate::CLIMATE_FAN_DIFFUSE:
-                    fanSpeed = MHI_FAN_AUTO;
-                    swingH = MHI_HS_LEFTRIGHT;
-                    break;
+           //     case climate::CLIMATE_FAN_MIDDLE:
+           //         fanSpeed = MHI_FAN_AUTO;
+           //         swingH = MHI_HS_MIDDLE;
+           //         break;
+           //     case climate::CLIMATE_FAN_FOCUS:
+           //         fanSpeed = MHI_FAN_AUTO;
+           //         swingH = MHI_HS_RIGHTLEFT;
+           //         break;
+           //     case climate::CLIMATE_FAN_DIFFUSE:
+           //         fanSpeed = MHI_FAN_AUTO;
+           //         swingH = MHI_HS_LEFTRIGHT;
+           //         break;
                 case climate::CLIMATE_FAN_AUTO:
                     fanSpeed = MHI_FAN_AUTO;
+                    break;
                 default:
                     fanSpeed = MHI_FAN_AUTO;
                     break;

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -240,6 +240,10 @@ namespace esphome {
 
             // Power and operating mode
             switch (this->mode) {
+              case climate::CLIMATE_MODE_AUTO:
+                    operatingMode = MHI_AUTO;
+                    swingV = MHI_VS_MIDDLE; // custom preferred value for this mode
+                    break;
                 case climate::CLIMATE_MODE_COOL:
                     operatingMode = MHI_COOL;
                     swingV = MHI_VS_UP; // custom preferred value for this mode
@@ -247,10 +251,6 @@ namespace esphome {
                 case climate::CLIMATE_MODE_HEAT:
                     operatingMode = MHI_HEAT;
                     swingV = MHI_VS_DOWN; // custom preferred value for this mode
-                    break;
-                case climate::CLIMATE_MODE_AUTO:
-                    operatingMode = MHI_AUTO;
-                    swingV = MHI_VS_MIDDLE; // custom preferred value for this mode
                     break;
                 case climate::CLIMATE_MODE_FAN_ONLY:
                     operatingMode = MHI_FAN;
@@ -261,8 +261,8 @@ namespace esphome {
                     swingV = MHI_VS_MIDDLE; // custom preferred value for this mode
                     break;
                 case climate::CLIMATE_MODE_OFF:
-                default:
                     powerMode = MHI_OFF;
+                default:
                     break;
             }
 

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -320,7 +320,7 @@ namespace esphome {
                     break;
             }
             
-            switch (this->preset) {
+            switch (this->preset.value()) {
                 case climate::CLIMATE_PRESET_NONE:
                     _3DAuto = MHI_3DAUTO_OFF; // set 3Dmode to off
                     fanSpeed = MHI_FAN_AUTO; // set fan to Auto

--- a/esphome/components/mhi/mhi.cpp
+++ b/esphome/components/mhi/mhi.cpp
@@ -310,7 +310,7 @@ namespace esphome {
                     fanSpeed = MHI_FAN_AUTO;
                     swingH = MHI_HS_LEFTRIGHT;
                     break;
-               case climate::climate::CLIMATE_PRESET_ECO: //Preset mode to set unit to ECO
+               case climate::CLIMATE_PRESET_ECO: //Preset mode to set unit to ECO
                     fanSpeed = MHI_ECO;
                     break;
                 case climate::CLIMATE_FAN_AUTO:

--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -18,6 +18,9 @@ namespace esphome {
                         climate::CLIMATE_FAN_MIDDLE, climate::CLIMATE_FAN_FOCUS,
                         climate::CLIMATE_FAN_DIFFUSE
                     },
+                    std::set<climate::ClimatePreset>{
+                        climate::CLIMATE_PRESET_ECO
+                    },
                     std::set<climate::ClimateSwingMode>{
                         climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
                         climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH

--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -14,9 +14,7 @@ namespace esphome {
                     MHI_TEMP_MIN, MHI_TEMP_MAX, 1.0f, true, true,
                     std::set<climate::ClimateFanMode>{
                         climate::CLIMATE_FAN_AUTO, climate::CLIMATE_FAN_LOW,
-                        climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH,
-                        climate::CLIMATE_FAN_MIDDLE, climate::CLIMATE_FAN_FOCUS,
-                        climate::CLIMATE_FAN_DIFFUSE
+                        climate::CLIMATE_FAN_MEDIUM, climate::CLIMATE_FAN_HIGH
                     },
                     std::set<climate::ClimateSwingMode>{
                         climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,

--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -18,12 +18,12 @@ namespace esphome {
                         climate::CLIMATE_FAN_MIDDLE, climate::CLIMATE_FAN_FOCUS,
                         climate::CLIMATE_FAN_DIFFUSE
                     },
-                    std::set<climate::ClimatePreset>{
-                        climate::CLIMATE_PRESET_ECO
-                    },
                     std::set<climate::ClimateSwingMode>{
                         climate::CLIMATE_SWING_OFF, climate::CLIMATE_SWING_VERTICAL,
                         climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH
+                    },
+                    std::set<climate::ClimatePreset>{
+                        climate::CLIMATE_PRESET_ECO
                     }
                 ) {}
 

--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -23,7 +23,8 @@ namespace esphome {
                         climate::CLIMATE_SWING_HORIZONTAL, climate::CLIMATE_SWING_BOTH
                     },
                     std::set<climate::ClimatePreset>{
-                        climate::CLIMATE_PRESET_ECO
+                        climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO,
+                        climate::CLIMATE_PRESET_BOOST 
                     }
                 ) {}
 

--- a/esphome/components/mhi/mhi.h
+++ b/esphome/components/mhi/mhi.h
@@ -24,7 +24,7 @@ namespace esphome {
                     },
                     std::set<climate::ClimatePreset>{
                         climate::CLIMATE_PRESET_NONE, climate::CLIMATE_PRESET_ECO,
-                        climate::CLIMATE_PRESET_BOOST 
+                        climate::CLIMATE_PRESET_BOOST, climate::CLIMATE_PRESET_ACTIVITY
                     }
                 ) {}
 


### PR DESCRIPTION
Hi

Have added Preset mode, 
ECO - this will add eco mode, fan can still be adjusted, but now in ECO mode.
BOOST - full speed, boost mode.
ACTIVITY - Special mode where A/C unit is in Night mode/10 degree.

Have removed various FAN mode, due to clash with remote IR, have not found a good way to get that working? Have comment the code, but not working 100%.

Probebly some bugs left, but this is a start.

Karl Linder